### PR TITLE
Make Naturals public

### DIFF
--- a/src/main/scala/io/borsh4s/Naturals.scala
+++ b/src/main/scala/io/borsh4s/Naturals.scala
@@ -2,7 +2,7 @@ package io.borsh4s
 
 import scala.annotation.targetName
 
-private object Naturals:
+object Naturals:
   opaque type Nat = Int
 
   object Nat:


### PR DESCRIPTION
`BinarySize` can't be instantiated for custom types because it depends on `Nat` which is inside a `private object`.

This solves #173